### PR TITLE
Update parser to support edit of emergency contact details

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -50,7 +50,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_ROOM_NUMBER + "ROOMNUMBER] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_EMERGENCY_NAME + "EMERGENCY_NAME] "
-            + "[" + PREFIX_EMERGENCY_PHONE + "EMERGENCY_CONTACT_NUMBER] "
+            + "[" + PREFIX_EMERGENCY_PHONE + "EMERGENCY_PHONE] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -3,6 +3,8 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_NUMBER;
@@ -46,6 +48,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ROOM_NUMBER + "ROOMNUMBER]"
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_EMERGENCY_NAME + "EMERGENCY_NAME] "
+            + "[" + PREFIX_EMERGENCY_PHONE + "EMERGENCY_CONTACT_NUMBER] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -110,9 +110,9 @@ public class EditCommand extends Command {
         RoomNumber updatedRoomNumber = editPersonDescriptor.getRoomNumber()
                 .orElse(personToEdit.getRoomNumber().orElse(null));
         Name updatedEmergencyName = editPersonDescriptor.getEmergencyName()
-                .orElse(personToEdit.getEmergencyContact().flatMap(EmergencyContact::getName).orElse(null));
+                .orElse(personToEdit.getEmergencyContactName().orElse(null));
         Phone updatedEmergencyPhone = editPersonDescriptor.getEmergencyPhone()
-                .orElse(personToEdit.getEmergencyContact().flatMap(EmergencyContact::getPhone).orElse(null));
+                .orElse(personToEdit.getEmergencyContactPhone().orElse(null));
 
         EmergencyContact updatedEmergencyContact;
         if (updatedEmergencyName == null && updatedEmergencyPhone == null) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -26,6 +26,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -46,7 +47,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_ROOM_NUMBER + "ROOMNUMBER]"
+            + "[" + PREFIX_ROOM_NUMBER + "ROOMNUMBER] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_EMERGENCY_NAME + "EMERGENCY_NAME] "
             + "[" + PREFIX_EMERGENCY_PHONE + "EMERGENCY_CONTACT_NUMBER] "
@@ -106,10 +107,25 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
-        RoomNumber updatedRoomNumber = editPersonDescriptor.getRoomNumber().orElse(personToEdit.getRoomNumber());
+        RoomNumber updatedRoomNumber = editPersonDescriptor.getRoomNumber()
+                .orElse(personToEdit.getRoomNumber().orElse(null));
+        Name updatedEmergencyName = editPersonDescriptor.getEmergencyName()
+                .orElse(personToEdit.getEmergencyContact().flatMap(EmergencyContact::getName).orElse(null));
+        Phone updatedEmergencyPhone = editPersonDescriptor.getEmergencyPhone()
+                .orElse(personToEdit.getEmergencyContact().flatMap(EmergencyContact::getPhone).orElse(null));
+
+        EmergencyContact updatedEmergencyContact;
+        if (updatedEmergencyName == null && updatedEmergencyPhone == null) {
+            // emergency contact does not exist
+            updatedEmergencyContact = null;
+        } else {
+            updatedEmergencyContact = new EmergencyContact(updatedEmergencyName, updatedEmergencyPhone);
+        }
+
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedRoomNumber, updatedAddress, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedRoomNumber,
+                updatedAddress, updatedEmergencyContact, updatedTags);
     }
 
     @Override
@@ -146,6 +162,8 @@ public class EditCommand extends Command {
         private Email email;
         private RoomNumber roomNumber;
         private Address address;
+        private Name emergencyName;
+        private Phone emergencyPhone;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -160,13 +178,16 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setRoomNumber(toCopy.roomNumber);
             setAddress(toCopy.address);
+            setEmergencyName(toCopy.emergencyName);
+            setEmergencyPhone(toCopy.emergencyPhone);
             setTags(toCopy.tags);
         }
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, roomNumber, address, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, roomNumber,
+                    address, emergencyName, emergencyPhone, tags);
         }
 
         public void setName(Name name) {
@@ -194,10 +215,12 @@ public class EditCommand extends Command {
         }
 
         public void setRoomNumber(RoomNumber roomNumber) {
-            this.roomNumber = roomNumber; }
+            this.roomNumber = roomNumber;
+        }
 
         public Optional<RoomNumber> getRoomNumber() {
-            return Optional.ofNullable(roomNumber); }
+            return Optional.ofNullable(roomNumber);
+        }
 
         public void setAddress(Address address) {
             this.address = address;
@@ -205,6 +228,22 @@ public class EditCommand extends Command {
 
         public Optional<Address> getAddress() {
             return Optional.ofNullable(address);
+        }
+
+        public void setEmergencyName(Name emergencyName) {
+            this.emergencyName = emergencyName;
+        }
+
+        public Optional<Name> getEmergencyName() {
+            return Optional.ofNullable(emergencyName);
+        }
+
+        public void setEmergencyPhone(Phone emergencyPhone) {
+            this.emergencyPhone = emergencyPhone;
+        }
+
+        public Optional<Phone> getEmergencyPhone() {
+            return Optional.ofNullable(emergencyPhone);
         }
 
         /**
@@ -252,6 +291,8 @@ public class EditCommand extends Command {
                     .add("email", email)
                     .add("room number", roomNumber)
                     .add("address", address)
+                    .add("emergency name", emergencyName)
+                    .add("emergency phone", emergencyPhone)
                     .add("tags", tags)
                     .toString();
         }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -48,15 +48,15 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        RoomNumber roomNumber = null;
+        if (argMultimap.getValue(PREFIX_ROOM_NUMBER).isPresent()) {
+            roomNumber = ParserUtil.parseRoomNumber(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
+        }
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, tagList);
-
-        // if room number is provided, use overloaded person constructor
-        if (arePrefixesPresent(argMultimap, PREFIX_ROOM_NUMBER)) {
-            RoomNumber roomNumber = ParserUtil.parseRoomNumber(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
-            person = new Person(name, phone, email, roomNumber, address, tagList);
-        }
+        // Allow setting optional parameter roomNumber in add command
+        // Do not allow setting optional parameter emergencyContact in add command
+        Person person = new Person(name, phone, email, roomNumber, address, null, tagList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,6 +11,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ROOM_NUMBER = new Prefix("r/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
+    public static final Prefix PREFIX_EMERGENCY_NAME = new Prefix("en/");
+    public static final Prefix PREFIX_EMERGENCY_PHONE = new Prefix("ep/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_NUMBER;
@@ -34,7 +36,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROOM_NUMBER,
-                        PREFIX_ADDRESS, PREFIX_TAG);
+                        PREFIX_ADDRESS, PREFIX_EMERGENCY_NAME, PREFIX_EMERGENCY_PHONE, PREFIX_TAG);
 
         Index index;
 
@@ -45,7 +47,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ROOM_NUMBER, PREFIX_ADDRESS);
+                PREFIX_ROOM_NUMBER, PREFIX_EMERGENCY_NAME, PREFIX_EMERGENCY_PHONE, PREFIX_ADDRESS);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -64,6 +66,14 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_EMERGENCY_NAME).isPresent()) {
+            editPersonDescriptor.setEmergencyName(ParserUtil.parseName(argMultimap.getValue(PREFIX_EMERGENCY_NAME)
+                    .get()));
+        }
+        if (argMultimap.getValue(PREFIX_EMERGENCY_PHONE).isPresent()) {
+            editPersonDescriptor.setEmergencyPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_EMERGENCY_PHONE)
+                    .get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/seedu/address/model/person/EmergencyContact.java
+++ b/src/main/java/seedu/address/model/person/EmergencyContact.java
@@ -1,14 +1,14 @@
 package seedu.address.model.person;
 
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-
 import java.util.Objects;
+import java.util.Optional;
 
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
  * Represents a Person's emergency contact in the address book.
- * Guarantees: details are present and not null, field values are validated, immutable.
+ * Guarantees: field values are validated, immutable.
+ * Note: all fields are optional.
  */
 public class EmergencyContact {
 
@@ -17,20 +17,19 @@ public class EmergencyContact {
     private final Phone phone;
 
     /**
-     * Every field must be present and not null.
+     * Note: All fields are optional and can be null.
      */
     public EmergencyContact(Name name, Phone phone) {
-        requireAllNonNull(name, phone);
         this.name = name;
         this.phone = phone;
     }
 
-    public Name getName() {
-        return name;
+    public Optional<Name> getName() {
+        return Optional.ofNullable(name);
     }
 
-    public Phone getPhone() {
-        return phone;
+    public Optional<Phone> getPhone() {
+        return Optional.ofNullable(phone);
     }
 
     /**
@@ -47,8 +46,8 @@ public class EmergencyContact {
         }
 
         EmergencyContact otherEmergencyContact = (EmergencyContact) other;
-        return name.equals(otherEmergencyContact.name)
-                && phone.equals(otherEmergencyContact.phone);
+        return Objects.equals(name, otherEmergencyContact.name)
+                && Objects.equals(phone, otherEmergencyContact.phone);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -12,7 +13,7 @@ import seedu.address.model.tag.Tag;
 
 /**
  * Represents a Person in the address book.
- * Guarantees: details are present and not null, field values are validated, immutable.
+ * Guarantees: non-optional details are present and not null, field values are validated, immutable.
  */
 public class Person {
 
@@ -28,7 +29,8 @@ public class Person {
     private final Set<Tag> tags = new HashSet<>();
 
     /**
-     * AB3 basic constructor.
+     * Basic constructor.
+     * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, tags);
@@ -37,21 +39,25 @@ public class Person {
         this.email = email;
         this.roomNumber = null;
         this.address = address;
-        this.emergencyContact = new EmergencyContact(new Name("Aiken"), new Phone("12345678"));
+        this.emergencyContact = null;
         this.tags.addAll(tags);
     }
 
     /**
-     * Overloaded constructor that includes roomnumber
+     * Overloaded constructor that includes optional parameters.
+     * Every field must be present and not null, except for optional parameters.
+     * Non-optional params: name, phone, email, address, and tags.
+     * Optional params: roomNumber and emergencyContact.
      */
-    public Person(Name name, Phone phone, Email email, RoomNumber roomNumber, Address address, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email, RoomNumber roomNumber,
+                  Address address, EmergencyContact emergencyContact, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.roomNumber = roomNumber;
         this.address = address;
-        this.emergencyContact = new EmergencyContact(new Name("Aiken"), new Phone("12345678"));
+        this.emergencyContact = emergencyContact;
         this.tags.addAll(tags);
     }
 
@@ -67,15 +73,16 @@ public class Person {
         return email;
     }
 
-    public RoomNumber getRoomNumber() {
-        return roomNumber; }
+    public Optional<RoomNumber> getRoomNumber() {
+        return Optional.ofNullable(roomNumber);
+    }
 
     public Address getAddress() {
         return address;
     }
 
-    public EmergencyContact getEmergencyContact() {
-        return emergencyContact;
+    public Optional<EmergencyContact> getEmergencyContact() {
+        return Optional.ofNullable(emergencyContact);
     }
 
     /**
@@ -131,9 +138,9 @@ public class Person {
         return name.equals(otherPerson.name)
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
-                && (roomNumber == null ? otherPerson.roomNumber == null : roomNumber.equals(otherPerson.roomNumber))
+                && (Objects.equals(roomNumber, otherPerson.roomNumber))
                 && address.equals(otherPerson.address)
-                && emergencyContact.equals(otherPerson.emergencyContact)
+                && (Objects.equals(emergencyContact, otherPerson.emergencyContact))
                 && tags.equals(otherPerson.tags);
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -85,6 +85,14 @@ public class Person {
         return Optional.ofNullable(emergencyContact);
     }
 
+    public Optional<Name> getEmergencyContactName() {
+        return Optional.ofNullable(emergencyContact).flatMap(EmergencyContact::getName);
+    }
+
+    public Optional<Phone> getEmergencyContactPhone() {
+        return Optional.ofNullable(emergencyContact).flatMap(EmergencyContact::getPhone);
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -158,7 +158,7 @@ public class Person {
                 .add("email", email)
                 .add("room number", roomNumber)
                 .add("address", address)
-                .add("emergencyContact", emergencyContact)
+                .add("emergency contact", emergencyContact)
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -8,6 +8,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -22,21 +23,23 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new RoomNumber("01-0123"), new Address("Blk 30 Geylang Street 29, #06-40"),
+                new EmergencyContact(new Name("Aiken"), new Phone("81234567")),
                 getTagSet("friends")),
-            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("b()erniceyu@example.com"),
-                new RoomNumber("01-0124"), new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
+            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
+                new RoomNumber("01-0124"), new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), null,
                 getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new RoomNumber("02-0123"), new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
+                new EmergencyContact(new Name("Dueet"), new Phone("12345678")),
                 getTagSet("neighbours")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new RoomNumber("08-8888"), new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
+                new RoomNumber("08-8888"), new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), null,
                 getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new RoomNumber("04-4444"), new Address("Blk 47 Tampines Street 20, #17-35"),
+                new RoomNumber("04-4444"), new Address("Blk 47 Tampines Street 20, #17-35"), null,
                 getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new RoomNumber("11-1111"), new Address("Blk 45 Aljunied Street 85, #11-31"),
+                new RoomNumber("11-1111"), new Address("Blk 45 Aljunied Street 85, #11-31"), null,
                 getTagSet("colleagues"))
         };
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -55,8 +56,9 @@ class JsonAdaptedPerson {
         name = source.getName().fullName;
         phone = source.getPhone().value;
         email = source.getEmail().value;
-        roomNumber = source.getRoomNumber().value;
+        roomNumber = source.getRoomNumber().map(rn -> rn.value).orElse(null);
         address = source.getAddress().value;
+        //TODO: Implement serialization for emergency contact in the storage commit.
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -100,6 +102,7 @@ class JsonAdaptedPerson {
         }
         final Email modelEmail = new Email(email);
 
+        //TODO: Make room number optional in the storage commit.
         if (roomNumber == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     RoomNumber.class.getSimpleName()));
@@ -117,8 +120,12 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
+        final EmergencyContact modelEmergencyContact = null;
+        //TODO: Implement parsing and marshalling in the storage commit.
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelRoomNumber, modelAddress, modelTags);
+        return new Person(modelName, modelPhone, modelEmail, modelRoomNumber, modelAddress,
+                modelEmergencyContact, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -7,6 +7,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Person;
 
 /**
@@ -59,15 +60,22 @@ public class PersonCard extends UiPart<Region> {
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
 
-        // check if room number label is null
-        if (person.getRoomNumber() != null) {
-            roomNumber.setText("#" + person.getRoomNumber().value);
-        } else {
-            roomNumber.setText("# Room not yet assigned");
-        }
+        // display default text if room number is not assigned
+        roomNumber.setText(
+                person.getRoomNumber().map(room -> "#" + room.value)
+                        .orElse("Room not yet assigned")
+        );
 
-        emergencyContactName.setText(person.getEmergencyContact().getName().fullName);
-        emergencyContactPhone.setText(person.getEmergencyContact().getPhone().value);
+        // display default text if emergency contact is not assigned
+        emergencyContactName.setText(
+                person.getEmergencyContact().flatMap(EmergencyContact::getName).map(name -> name.fullName)
+                        .orElse("Emergency contact name not yet assigned")
+        );
+        emergencyContactPhone.setText(
+                person.getEmergencyContact().flatMap(EmergencyContact::getPhone).map(phone -> phone.value)
+                        .orElse("Emergency contact phone not yet assigned")
+        );
+
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -7,7 +7,6 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
-import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Person;
 
 /**
@@ -68,11 +67,11 @@ public class PersonCard extends UiPart<Region> {
 
         // display default text if emergency contact is not assigned
         emergencyContactName.setText(
-                person.getEmergencyContact().flatMap(EmergencyContact::getName).map(name -> name.fullName)
+                person.getEmergencyContactName().map(name -> name.fullName)
                         .orElse("Emergency contact name not yet assigned")
         );
         emergencyContactPhone.setText(
-                person.getEmergencyContact().flatMap(EmergencyContact::getPhone).map(phone -> phone.value)
+                person.getEmergencyContactPhone().map(phone -> phone.value)
                         .orElse("Emergency contact phone not yet assigned")
         );
 

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -70,7 +70,9 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", room number="
                 + editPersonDescriptor.getRoomNumber().orElse(null) + ", address="
-                + editPersonDescriptor.getAddress().orElse(null) + ", tags="
+                + editPersonDescriptor.getAddress().orElse(null) + ", emergency name="
+                + editPersonDescriptor.getEmergencyName().orElse(null) + ", emergency phone="
+                + editPersonDescriptor.getEmergencyPhone().orElse(null) + ", tags="
                 + editPersonDescriptor.getTags().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -151,13 +151,13 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_optionalFieldsMissing_success() {
-        Person expectedPerson = new PersonBuilder(AMY).withNoRoomNumber().build();
         // roomNumber not present
+        Person expectedPerson = new PersonBuilder(AMY).withNoRoomNumber().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
                 + ADDRESS_DESC_AMY + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
-        expectedPerson = new PersonBuilder(AMY).withTags().build();
 
         // zero tags
+        expectedPerson = new PersonBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
                         + ROOM_NUMBER_DESC_AMY + ADDRESS_DESC_AMY,
                 new AddCommand(expectedPerson));

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -104,7 +104,7 @@ public class PersonTest {
                 + ", email=" + ALICE.getEmail()
                 + ", room number=" + ALICE.getRoomNumber().orElse(null)
                 + ", address=" + ALICE.getAddress()
-                + ", emergencyContact=" + ALICE.getEmergencyContact().orElse(null)
+                + ", emergency contact=" + ALICE.getEmergencyContact().orElse(null)
                 + ", tags=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -102,9 +102,9 @@ public class PersonTest {
                 + "{name=" + ALICE.getName()
                 + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail()
-                + ", room number=" + ALICE.getRoomNumber()
+                + ", room number=" + ALICE.getRoomNumber().orElse(null)
                 + ", address=" + ALICE.getAddress()
-                + ", emergencyContact=" + ALICE.getEmergencyContact()
+                + ", emergencyContact=" + ALICE.getEmergencyContact().orElse(null)
                 + ", tags=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -30,7 +30,7 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
-    private static final String VALID_ROOM_NUMBER = BENSON.getRoomNumber().toString();
+    private static final String VALID_ROOM_NUMBER = BENSON.getRoomNumber().get().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -7,7 +7,6 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -39,8 +38,8 @@ public class EditPersonDescriptorBuilder {
         descriptor.setEmail(person.getEmail());
         descriptor.setRoomNumber(person.getRoomNumber().orElse(null));
         descriptor.setAddress(person.getAddress());
-        descriptor.setEmergencyName(person.getEmergencyContact().flatMap(EmergencyContact::getName).orElse(null));
-        descriptor.setEmergencyPhone(person.getEmergencyContact().flatMap(EmergencyContact::getPhone).orElse(null));
+        descriptor.setEmergencyName(person.getEmergencyContactName().orElse(null));
+        descriptor.setEmergencyPhone(person.getEmergencyContactPhone().orElse(null));
         descriptor.setTags(person.getTags());
     }
 

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -36,8 +37,10 @@ public class EditPersonDescriptorBuilder {
         descriptor.setName(person.getName());
         descriptor.setPhone(person.getPhone());
         descriptor.setEmail(person.getEmail());
-        descriptor.setRoomNumber(person.getRoomNumber());
+        descriptor.setRoomNumber(person.getRoomNumber().orElse(null));
         descriptor.setAddress(person.getAddress());
+        descriptor.setEmergencyName(person.getEmergencyContact().flatMap(EmergencyContact::getName).orElse(null));
+        descriptor.setEmergencyPhone(person.getEmergencyContact().flatMap(EmergencyContact::getPhone).orElse(null));
         descriptor.setTags(person.getTags());
     }
 
@@ -78,6 +81,22 @@ public class EditPersonDescriptorBuilder {
      */
     public EditPersonDescriptorBuilder withAddress(String address) {
         descriptor.setAddress(new Address(address));
+        return this;
+    }
+
+    /**
+     * Sets the {@code EmergencyName} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withEmergencyName(String emergencyName) {
+        descriptor.setEmergencyName(new Name(emergencyName));
+        return this;
+    }
+
+    /**
+     * Sets the {@code EmergencyPhone} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withEmergencyPhone(String emergencyPhone) {
+        descriptor.setEmergencyPhone(new Phone(emergencyPhone));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -22,12 +23,15 @@ public class PersonBuilder {
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_ROOM_NUMBER = "01-0123";
+    public static final String DEFAULT_EMERGENCY_NAME = "Bob Bee";
+    public static final String DEFAULT_EMERGENCY_PHONE = "98765432";
 
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
     private RoomNumber roomNumber;
+    private EmergencyContact emergencyContact;
     private Set<Tag> tags;
 
     /**
@@ -39,6 +43,7 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         roomNumber = new RoomNumber(DEFAULT_ROOM_NUMBER);
         address = new Address(DEFAULT_ADDRESS);
+        emergencyContact = null;
         tags = new HashSet<>();
     }
 
@@ -49,8 +54,9 @@ public class PersonBuilder {
         name = personToCopy.getName();
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
-        roomNumber = personToCopy.getRoomNumber();
+        roomNumber = personToCopy.getRoomNumber().orElse(null);
         address = personToCopy.getAddress();
+        emergencyContact = personToCopy.getEmergencyContact().orElse(null);
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -111,15 +117,25 @@ public class PersonBuilder {
     }
 
     /**
-     * Builds a person using AB3 constructor if roomNumber is not null,
-     * else uses overloaded constructor to build person
+     * Sets the {@code EmergencyContact} of the {@code Person} that we are building.
      */
-    public Person build() {
-        if (roomNumber != null) {
-            return new Person(name, phone, email, roomNumber, address, tags);
-        } else {
-            return new Person(name, phone, email, address, tags);
-        }
+    public PersonBuilder withEmergencyContact(String name, String phone) {
+        this.emergencyContact = new EmergencyContact(new Name(name), new Phone(phone));
+        return this;
     }
 
+    /**
+     * Sets the {@code EmergencyContact} of the {@code Person} that we are building to null.
+     */
+    public PersonBuilder withNoEmergencyContact() {
+        this.emergencyContact = null;
+        return this;
+    }
+
+    /**
+     * Builds a person using AB3 constructor.
+     */
+    public Person build() {
+        return new Person(name, phone, email, roomNumber, address, emergencyContact, tags);
+    }
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -2,6 +2,8 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_NUMBER;
@@ -11,6 +13,7 @@ import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 
@@ -34,7 +37,9 @@ public class PersonUtil {
         sb.append(PREFIX_NAME + person.getName().fullName + " ");
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
-        sb.append(PREFIX_ROOM_NUMBER + person.getRoomNumber().value + " ");
+        if (person.getRoomNumber().isPresent()) {
+            sb.append(PREFIX_ROOM_NUMBER + person.getRoomNumber().get().value + " ");
+        }
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
@@ -53,6 +58,10 @@ public class PersonUtil {
         descriptor.getRoomNumber().ifPresent(roomNumber -> sb.append(PREFIX_ROOM_NUMBER).append(roomNumber.value)
                 .append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
+        descriptor.getEmergencyName().ifPresent(emergencyName -> sb.append(PREFIX_EMERGENCY_NAME)
+                .append(emergencyName.fullName).append(" "));
+        descriptor.getEmergencyPhone().ifPresent(emergencyPhone -> sb.append(PREFIX_EMERGENCY_PHONE)
+                .append(emergencyPhone.value).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -13,7 +13,6 @@ import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 


### PR DESCRIPTION
## **Summary of this PR**
- Make room number and emergency contact optional for Person
- Make emergency name and emergency phone optional for EmergencyContact to allow individual changes
- Update parsers and commands to support edit of emergency contact details

Fixes #69 