### PR TITLE
Clear undo stack on `import` to remove erratic behaviour when combined with `undo`

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ConcreteCommand;
 import seedu.address.logic.commands.FileAccessCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -62,6 +63,8 @@ public class LogicManager implements Logic {
         // No need to check for success as the command will exit through an exception if it fails
         if (command instanceof ConcreteCommand) {
             model.pushToUndoStack((ConcreteCommand) command);
+        } else if (command instanceof ImportCommand) {
+            model.clearUndoStack();
         }
 
         try {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -124,4 +124,9 @@ public interface Model {
      * Undoes the most recent concrete command.
      */
     CommandResult undoAddressBook();
+
+    /**
+     * Clears the undo stack.
+     */
+    void clearUndoStack();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -195,4 +195,10 @@ public class ModelManager implements Model {
         ConcreteCommand command = undoStack.pop();
         return command.undo(this);
     }
+
+    @Override
+    public void clearUndoStack() {
+        assert undoStack != null;
+        undoStack.clear();
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -240,6 +240,11 @@ public class AddCommandTest {
         public CommandResult undoAddressBook() {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void clearUndoStack() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_FILE_PATH;
 import static seedu.address.logic.commands.CommandTestUtil.assertFileAccessCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertFileAccessCommandSuccess;
 import static seedu.address.logic.commands.ImportCommand.FILE_DATA_LOAD_ERROR_FORMAT;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -25,12 +26,13 @@ import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.Storage;
 
 public class ImportCommandTest {
-    private Model model = new ModelManager();
-    private Model expectedModel = new ModelManager();
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     private StorageStub storage = new StorageStub();
     private StorageStub expectedStorage = new StorageStub();
 
+    @Test
     public void execute_importValidFile_success() {
         ImportCommand importCommand = new ImportCommand(VALID_FILE_PATH);
         String expectedMessage = String.format(ImportCommand.MESSAGE_SUCCESS, VALID_FILE_PATH);
@@ -110,6 +112,11 @@ public class ImportCommandTest {
         @Override
         public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
             throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof StorageStub;
         }
     }
 }


### PR DESCRIPTION
Fixes #204 